### PR TITLE
allow connect by serial number or address

### DIFF
--- a/brewblox_devcon_spark/__main__.py
+++ b/brewblox_devcon_spark/__main__.py
@@ -16,6 +16,11 @@ def create_parser(default_name='spark'):
     parser.add_argument('--system-database',
                         help='Backing file for the system object database. [%(default)s]',
                         default='brewblox_sys_db.json')
+    parser.add_argument('--device-port',
+                        help='Spark device port. Automatically determined if not set. [%(default)s]')
+    parser.add_argument('--device-number',
+                        help='Spark serial number. Any spark is valid if not set. '
+                        'This will be ignored if --device-port is specified. [%(default)s]')
     return parser
 
 

--- a/brewblox_devcon_spark/__main__.py
+++ b/brewblox_devcon_spark/__main__.py
@@ -18,7 +18,7 @@ def create_parser(default_name='spark'):
                         default='brewblox_sys_db.json')
     parser.add_argument('--device-port',
                         help='Spark device port. Automatically determined if not set. [%(default)s]')
-    parser.add_argument('--device-number',
+    parser.add_argument('--device-id',
                         help='Spark serial number. Any spark is valid if not set. '
                         'This will be ignored if --device-port is specified. [%(default)s]')
     return parser

--- a/brewblox_devcon_spark/api.py
+++ b/brewblox_devcon_spark/api.py
@@ -36,14 +36,14 @@ class ObjectApi(Api):
     async def create(self, service_id: str, obj_type: int, data: dict) -> dict:
         object = {
             'service_id': service_id,
-            'type': obj_type,
-            'data': data
+            'object_type': obj_type,
+            'object_data': data
         }
 
         await self._ctrl.create_object(
-            type=obj_type,
-            size=18,  # TODO(Bob): fix protocol
-            data=data
+            object_type=obj_type,
+            object_size=18,  # TODO(Bob): fix protocol
+            object_data=data
         )
 
         # TODO(Bob): get controller id from create object
@@ -65,16 +65,16 @@ class ObjectApi(Api):
     async def read(self, service_id: str, obj_type: int=0) -> dict:
         return await self._ctrl.read_value(
             object_id=service_id,
-            type=obj_type,
-            size=0
+            object_type=obj_type,
+            object_size=0
         )
 
     async def update(self, service_id: str, obj_type: int, data: dict) -> dict:
         return await self._ctrl.write_value(
             object_id=service_id,
-            type=obj_type,
-            size=0,
-            data=data
+            object_type=obj_type,
+            object_size=0,
+            object_data=data
         )
 
     async def delete(self, service_id: str) -> dict:
@@ -93,16 +93,16 @@ class SystemApi(Api):
     async def read(self, service_id: str) -> dict:
         return await self._ctrl.read_system_value(
             system_object_id=service_id,
-            type=0,
-            size=0
+            object_type=0,
+            object_size=0
         )
 
     async def update(self, service_id: str, obj_type: int, data: dict) -> dict:
         return await self._ctrl.write_system_value(
             system_object_id=service_id,
-            type=obj_type,
-            size=0,
-            data=data
+            object_type=obj_type,
+            object_size=0,
+            object_data=data
         )
 
 

--- a/brewblox_devcon_spark/commands.py
+++ b/brewblox_devcon_spark/commands.py
@@ -13,9 +13,9 @@ LOGGER = LOGGER = brewblox_logger(__name__)
 
 OBJECT_ID_KEY = 'object_id'
 SYSTEM_ID_KEY = 'system_object_id'
-OBJECT_TYPE_KEY = 'type'
-OBJECT_SIZE_KEY = 'size'
-OBJECT_DATA_KEY = 'data'
+OBJECT_TYPE_KEY = 'object_type'
+OBJECT_SIZE_KEY = 'object_size'
+OBJECT_DATA_KEY = 'object_data'
 OBJECT_LIST_KEY = 'objects'
 
 PROFILE_ID_KEY = 'profile_id'

--- a/brewblox_devcon_spark/communication.py
+++ b/brewblox_devcon_spark/communication.py
@@ -34,10 +34,6 @@ KNOWN_DEVICES = {
         id='Particle P1',
         desc=r'.*P1.*',
         hwid=r'USB VID\:PID=2B04\:C008.*'),
-    DeviceMatch(
-        id='Particle Electron',
-        desc=r'.*Electron.*',
-        hwid=r'USB VID\:PID=2d04\:c00a.*'),
 }
 
 

--- a/brewblox_devcon_spark/communication.py
+++ b/brewblox_devcon_spark/communication.py
@@ -6,7 +6,7 @@ import asyncio
 import re
 from collections import namedtuple
 from functools import partial
-from typing import Callable, Generator, Iterable, Tuple
+from typing import Callable, Generator, Iterable, Any
 
 import serial
 from brewblox_devcon_spark import brewblox_logger
@@ -16,10 +16,10 @@ from serial.tools import list_ports
 LOGGER = LOGGER = brewblox_logger(__name__)
 DEFAULT_BAUD_RATE = 57600
 
-PortType_ = Tuple[str, str, str]
+PortType_ = Any
 MessageCallback_ = Callable[['SparkConduit', str], None]
 
-DeviceMatch = namedtuple('DeviceMatcher', ['id', 'desc', 'hwid'])
+DeviceMatch = namedtuple('DeviceMatch', ['id', 'desc', 'hwid'])
 
 KNOWN_DEVICES = {
     DeviceMatch(
@@ -86,11 +86,11 @@ class SparkConduit():
     def is_bound(self):
         return self._serial and self._serial.is_open
 
-    def bind(self, device: str=None, loop: asyncio.BaseEventLoop=None):
+    def bind(self, device: str=None, serial_number: str=None, loop: asyncio.BaseEventLoop=None):
         self.close()
         self._loop = loop or asyncio.get_event_loop()
 
-        self._device = detect_device(device)
+        self._device = detect_device(device, serial_number)
         self._protocol = SparkProtocol(
             on_event=partial(self._do_callback, 'on_event'),
             on_data=partial(self._do_callback, 'on_data'))
@@ -217,28 +217,28 @@ def all_ports() -> Iterable[PortType_]:
     return tuple(list_ports.comports())
 
 
-def has_recognized_device(port: PortType_) -> bool:
-    for known_device in KNOWN_DEVICES:
-        if re.match(known_device.hwid, port.hwid):
-            return True
-    return False
+def recognized_ports(
+    allowed: Iterable[DeviceMatch]=KNOWN_DEVICES,
+    serial_number: str=None
+) -> Generator[PortType_, None, None]:
 
+    # Construct a regex OR'ing all allowed hardware ID matches
+    # Example result: (?:HWID_REGEX_ONE|HWID_REGEX_TWO)
+    matcher = f'(?:{"|".join([dev.hwid for dev in allowed])})'
 
-def recognized_ports(ports: Iterable[PortType_]=None) -> Generator[PortType_, None, None]:
-    ports = ports if ports is not None else all_ports()
-    for port in ports:
-        if has_recognized_device(port):
+    for port in list_ports.grep(matcher):
+        if serial_number is None or serial_number == port.serial_number:
             yield port
 
 
-def detect_device(device: str=None) -> str:
+def detect_device(device: str=None, serial_number: str=None) -> str:
     if device is None:
         try:
-            port = next(recognized_ports())
+            port = next(recognized_ports(serial_number=serial_number))
             device = port.device
-            LOGGER.info(f'Automatically detected {port}')
+            LOGGER.info(f'Automatically detected {[v for v in port]}')
         except StopIteration:
             raise ValueError(
-                f'Could not find recognized device. Known={[{d for d in p} for p in all_ports()]}')
+                f'Could not find recognized device. Known={[{v for v in p} for p in all_ports()]}')
 
     return device

--- a/brewblox_devcon_spark/device.py
+++ b/brewblox_devcon_spark/device.py
@@ -69,24 +69,29 @@ class SparkController():
 
     async def start(self, app: Type[web.Application]):
         await self.close()
+        config = app['config']
 
         self._object_cache = MemoryDataStore()
         await self._object_cache.start(loop=app.loop)
 
         self._object_store = FileDataStore(
-            filename=app['config']['database'],
+            filename=config['database'],
             read_only=False
         )
         await self._object_store.start(loop=app.loop)
 
         self._system_store = FileDataStore(
-            filename=app['config']['system_database'],
+            filename=config['system_database'],
             read_only=True
         )
         await self._system_store.start(loop=app.loop)
 
         self._commander = SparkCommander(app.loop)
-        await self._commander.bind(loop=app.loop)
+        await self._commander.bind(
+            loop=app.loop,
+            device=config['device_port'],
+            serial_number=config['device_number']
+        )
 
     async def close(self, *args, **kwargs):
         [

--- a/brewblox_devcon_spark/device.py
+++ b/brewblox_devcon_spark/device.py
@@ -90,7 +90,7 @@ class SparkController():
         await self._commander.bind(
             loop=app.loop,
             device=config['device_port'],
-            serial_number=config['device_number']
+            serial_number=config['device_id']
         )
 
     async def close(self, *args, **kwargs):

--- a/brewblox_sys_db.json
+++ b/brewblox_sys_db.json
@@ -1,1 +1,10 @@
-{"_default":{"1":{"controller_id":[2],"alias":"onewirebus"}}}
+{
+    "_default": {
+        "1": {
+            "controller_id": [
+                2
+            ],
+            "service_id": "onewirebus"
+        }
+    }
+}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -29,7 +29,7 @@ def app_config() -> dict:
         'database': 'test_db.json',
         'system_database': 'brewblox_sys_db.json',
         'device_port': '/dev/TESTEH',
-        'device_number': '1234'
+        'device_id': '1234'
     }
 
 
@@ -43,7 +43,7 @@ def sys_args(app_config) -> list:
         '--database', app_config['database'],
         '--system-database', app_config['system_database'],
         '--device-port', app_config['device_port'],
-        '--device-number', app_config['device_number'],
+        '--device-id', app_config['device_id'],
     ]
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,6 +28,8 @@ def app_config() -> dict:
         'debug': False,
         'database': 'test_db.json',
         'system_database': 'brewblox_sys_db.json',
+        'device_port': '/dev/TESTEH',
+        'device_number': '1234'
     }
 
 
@@ -40,6 +42,8 @@ def sys_args(app_config) -> list:
         '--port', str(app_config['port']),
         '--database', app_config['database'],
         '--system-database', app_config['system_database'],
+        '--device-port', app_config['device_port'],
+        '--device-number', app_config['device_number'],
     ]
 
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -96,7 +96,7 @@ async def test_create(app, client, object_args):
     object_args['id'] = 'other_obj'
     res = await client.post('/objects', json=object_args)
     assert res.status == 200
-    assert (await res.json())['type'] == object_args['type']
+    assert (await res.json())['object_type'] == object_args['type']
 
 
 async def test_read(app, client):

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -12,9 +12,9 @@ TESTED = commands.__name__
 def write_value_args():
     return dict(
         object_id=[127, 7],
-        type=6,
-        size=10,
-        data=bytes([0x0F]*10))
+        object_type=6,
+        object_size=10,
+        object_data=bytes([0x0F]*10))
 
 
 @pytest.fixture
@@ -28,9 +28,9 @@ def write_value_req(write_value_args):
 def write_value_resp(write_value_args):
     return dict(
         errcode=commands.ErrorcodeEnum.OK,
-        type=write_value_args['type'],
-        size=write_value_args['size'],
-        data=write_value_args['data']
+        object_type=write_value_args['object_type'],
+        object_size=write_value_args['object_size'],
+        object_data=write_value_args['object_data']
     )
 
 
@@ -74,7 +74,7 @@ def test_variable_id_length(write_value_args):
     # assert symmetrical encoding / decoding
     decoded = command.request.parse(bin_cmd)
     assert decoded.object_id == write_value_args['object_id']
-    assert decoded.data == write_value_args['data']
+    assert decoded.object_data == write_value_args['object_data']
 
 
 def test_command_from_decoded(write_value_args):

--- a/test/test_communication.py
+++ b/test/test_communication.py
@@ -11,7 +11,7 @@ from asynctest import CoroutineMock
 
 from brewblox_devcon_spark import communication
 
-DummyPortInfo = namedtuple('DummyPortInfo', ['device', 'description', 'hwid'])
+DummyPortInfo = namedtuple('DummyPortInfo', ['device', 'description', 'hwid', 'serial_number'])
 
 TESTED = communication.__name__
 LOGGER = logging.getLogger(__name__)
@@ -118,11 +118,21 @@ async def bound_conduit(loop, serial_mock, transport_mock, bound_collector):
 
 
 @pytest.fixture
-def list_ports_mock(mocker):
+def comports_mock(mocker):
     m = mocker.patch(TESTED + '.list_ports.comports')
     m.return_value = [
-        DummyPortInfo('/dev/dummy', 'Dummy', 'USB VID:PID=1a02:b123'),
-        DummyPortInfo('/dev/ttyX', 'Electron', 'USB VID:PID=2d04:c00a'),
+        DummyPortInfo('/dev/dummy', 'Dummy', 'USB VID:PID=1a02:b123', '1234'),
+        DummyPortInfo('/dev/ttyX', 'Electron', 'USB VID:PID=2d04:c00a', '4321'),
+    ]
+    return m
+
+
+@pytest.fixture
+def grep_ports_mock(mocker):
+    m = mocker.patch(TESTED + '.list_ports.grep')
+    m.return_value = [
+        DummyPortInfo('/dev/ttyX', 'Electron', 'USB VID:PID=2d04:c00a', '1234'),
+        DummyPortInfo('/dev/ttyX', 'Electron', 'USB VID:PID=2d04:c00a', '4321'),
     ]
     return m
 
@@ -236,27 +246,22 @@ async def test_conduit_err_callback(loop, serial_mock, transport_mock, expected_
     assert error_cb.call_args_list == [call(conduit, e) for e in expected_events]
 
 
-async def test_all_ports(list_ports_mock):
+async def test_all_ports(comports_mock):
     assert communication.all_ports()[1][0] == '/dev/ttyX'
 
 
-async def test_has_recognized_device(list_ports_mock):
-    dummy = list_ports_mock()
-    assert not communication.has_recognized_device(dummy[0])
-    assert communication.has_recognized_device(dummy[1])
+async def test_recognized_ports(grep_ports_mock):
+    dummy = grep_ports_mock()
+    recognized = [r for r in communication.recognized_ports()]
+    assert recognized == dummy
 
 
-async def test_recognized_ports(list_ports_mock):
-    dummy = list_ports_mock()
-    recognized = [r for r in communication.recognized_ports(dummy)]
-    assert recognized == [dummy[1]]
-
-
-async def test_detect_device(list_ports_mock):
-    dummy = list_ports_mock()
+async def test_detect_device(grep_ports_mock):
+    dummy = grep_ports_mock()
     assert communication.detect_device('dave') == 'dave'
-    assert communication.detect_device() == dummy[1].device
+    assert communication.detect_device() == dummy[0].device
+    assert communication.detect_device(serial_number='4321') == dummy[1].device
 
-    list_ports_mock.return_value = [dummy[0]]
+    grep_ports_mock.return_value = [dummy[0]]
     with pytest.raises(ValueError):
-        communication.detect_device()
+        communication.detect_device(serial_number='4321')

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -89,27 +89,27 @@ async def test_transcoding(app, client, commander_mock, store):
 
     retval = await controller.write_value(
         id='alias',
-        type=obj_type,
-        size=0,
-        data=obj
+        object_type=obj_type,
+        object_size=0,
+        object_data=obj
     )
-    assert retval['data'] == obj
+    assert retval['object_data'] == obj
 
     # Test correct processing of lists of objects
     commander_mock.execute = CoroutineMock(return_value=dict(
         objects=[
             # Call dict twice to avoid populating the list with references to the same dict
-            dict(type=obj_type, data=encoded),
-            dict(type=obj_type, data=encoded),
+            dict(object_type=obj_type, object_data=encoded),
+            dict(object_type=obj_type, object_data=encoded),
         ]
     ))
     retval = await controller.write_value(
-        id='alias',
-        type=obj_type,
-        size=0,
-        data=obj
+        object_id='alias',
+        object_type=obj_type,
+        object_size=0,
+        object_data=obj
     )
-    assert retval['objects'] == [dict(type=obj_type, data=obj)] * 2
+    assert retval['objects'] == [dict(object_type=obj_type, object_data=obj)] * 2
 
 
 async def test_resolve_id(app, client, commander_mock, store):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -18,7 +18,7 @@ def test_main(loop, mocker):
 
     main.main()
 
-    assert create_parser_mock.return_value.add_argument.call_count == 2
+    assert create_parser_mock.return_value.add_argument.call_count == 4
     create_mock.assert_called_once_with(parser=create_parser_mock.return_value)
     furnish_mock.assert_called_once_with(app_mock)
     run_mock.assert_called_once_with(app_mock)


### PR DESCRIPTION
Changelog:
* Found a bug where device attempted to codec encode the 'data' field in OneWireBus.proto
* Renamed object data key to `object_data`
* Added `--device-port` argument for directly connecting to a port
* Added `--device-id` argument for filtering devices by serial number

Resolves #10