### PR TITLE
implement caching

### DIFF
--- a/brewblox_devcon_spark/__main__.py
+++ b/brewblox_devcon_spark/__main__.py
@@ -6,7 +6,7 @@ from brewblox_devcon_spark import (broadcaster, commander, commander_sim,
                                    datastore, device)
 from brewblox_devcon_spark.api import (alias_api, conflict_api, debug_api,
                                        error_response, object_api, profile_api,
-                                       system_api)
+                                       system_api, updater)
 from brewblox_service import brewblox_logger, events, service
 
 LOGGER = brewblox_logger(__name__)
@@ -35,6 +35,10 @@ def create_parser(default_name='spark'):
     parser.add_argument('--broadcast-exchange',
                         help='Eventbus exchange to which controller state should be broadcasted. [%(default)s]',
                         default='brewcast')
+    parser.add_argument('--update-interval',
+                        help='Interval (in seconds) between update of controller values cache. [%(default)s]',
+                        type=int,
+                        default=2)
     return parser
 
 
@@ -56,6 +60,7 @@ def main():
     object_api.setup(app)
     profile_api.setup(app)
     system_api.setup(app)
+    updater.setup(app)
 
     events.setup(app)
     broadcaster.setup(app)

--- a/brewblox_devcon_spark/api/alias_api.py
+++ b/brewblox_devcon_spark/api/alias_api.py
@@ -10,7 +10,8 @@ from typing import List
 from aiohttp import web
 from brewblox_devcon_spark import datastore
 from brewblox_devcon_spark.api import API_ID_KEY
-from brewblox_devcon_spark.device import CONTROLLER_ID_KEY, SERVICE_ID_KEY
+from brewblox_devcon_spark.device import (CONTROLLER_ID_KEY, OBJECT_ID_KEY,
+                                          SERVICE_ID_KEY)
 from brewblox_service import brewblox_logger
 
 LOGGER = brewblox_logger(__name__)
@@ -25,6 +26,7 @@ class AliasApi():
 
     def __init__(self, app: web.Application):
         self._store = datastore.get_object_store(app)
+        self._cache = datastore.get_object_cache(app)
 
     async def create(self, service_id: str, controller_id: List[int]) -> dict:
         await self._store.insert_unique(
@@ -40,6 +42,12 @@ class AliasApi():
             id_key=SERVICE_ID_KEY,
             id_val=existing_id,
             obj={SERVICE_ID_KEY: new_id}
+        )
+
+        await self._cache.update_unique(
+            id_key=OBJECT_ID_KEY,
+            id_val=existing_id,
+            obj={OBJECT_ID_KEY: new_id}
         )
 
 

--- a/brewblox_devcon_spark/api/updater.py
+++ b/brewblox_devcon_spark/api/updater.py
@@ -1,0 +1,57 @@
+"""
+Maintains the object cache
+"""
+import asyncio
+from concurrent.futures import CancelledError
+
+from aiohttp import web
+from brewblox_devcon_spark.api.object_api import ObjectApi
+from brewblox_service import brewblox_logger, features
+
+LOGGER = brewblox_logger(__name__)
+routes = web.RouteTableDef()
+
+
+def setup(app: web.Application):
+    features.add(app, CacheUpdater(app))
+
+
+class CacheUpdater(features.ServiceFeature):
+    def __init__(self, app: web.Application=None):
+        super().__init__(app)
+        self._task: asyncio.Task = None
+
+    def __str__(self):
+        return f'{type(self).__name__}'
+
+    async def startup(self, app: web.Application):
+        await self.shutdown()
+        self._task = app.loop.create_task(self._update(app))
+
+    async def shutdown(self, *_):
+        if self._task:
+            self._task.cancel()
+            await asyncio.wait([self._task])
+            self._task = None
+
+    async def _update(self, app: web.Application):
+        LOGGER.info(f'Starting {self}')
+
+        try:
+            api = ObjectApi(app)
+            interval = app['config']['update_interval']
+
+        except Exception as ex:
+            LOGGER.error(f'{type(ex).__name__}: {str(ex)}', exc_info=True)
+            raise ex
+
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                await api.all(refresh=True)
+
+            except CancelledError:
+                break
+
+            except Exception as ex:  # pragma: no cover
+                LOGGER.warn(f'{self} encountered an error: {type(ex).__name__}={ex}')

--- a/brewblox_devcon_spark/commander_sim.py
+++ b/brewblox_devcon_spark/commander_sim.py
@@ -2,14 +2,18 @@
 Monkey patches commander.SparkCommander to not require an actual connection.
 """
 
-from brewblox_devcon_spark import commander, commands
+from functools import partialmethod
+
 from aiohttp import web
-from brewblox_service import features
+from brewblox_devcon_spark import commander, commands
 from brewblox_devcon_spark.commands import (OBJECT_DATA_KEY, OBJECT_ID_KEY,
                                             OBJECT_LIST_KEY, OBJECT_TYPE_KEY,
                                             PROFILE_ID_KEY, PROFILE_LIST_KEY,
                                             SYSTEM_ID_KEY)
-from functools import partialmethod
+from brewblox_service import brewblox_logger, features
+
+
+LOGGER = brewblox_logger(__name__)
 
 
 def setup(app: web.Application):
@@ -79,7 +83,6 @@ class SimulationResponder():
         obj = request.copy()
         obj[OBJECT_ID_KEY] = id
         self._objects[self._object_id(id)] = obj
-        print(self._objects)
         return {OBJECT_ID_KEY: id[:]}
 
     def _list_objects(self, request):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -35,6 +35,7 @@ def app_config() -> dict:
         'simulation': False,
         'broadcast_interval': 5,
         'broadcast_exchange': 'brewcast',
+        'update_interval': 2,
     }
 
 
@@ -52,6 +53,7 @@ def sys_args(app_config) -> list:
         '--device-id', app_config['device_id'],
         '--broadcast-interval', str(app_config['broadcast_interval']),
         '--broadcast-exchange', app_config['broadcast_exchange'],
+        '--update-interval', str(app_config['update_interval']),
     ]
 
 

--- a/test/test_broadcaster.py
+++ b/test/test_broadcaster.py
@@ -77,3 +77,16 @@ async def test_error(app, client, mock_api, mock_publisher):
     await asyncio.sleep(0.1)
     assert not b._task.done()
     assert mock_publisher.publish.call_count > 0
+
+
+async def test_startup_error(app, client, mocker):
+    logger_spy = mocker.spy(broadcaster, 'LOGGER')
+
+    del app['config']['broadcast_interval']
+
+    b = broadcaster.Broadcaster()
+
+    await b.startup(app)
+    await asyncio.sleep(0.01)
+    assert logger_spy.error.call_count == 1
+    await b.shutdown(app)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -95,7 +95,10 @@ async def test_transcoding(app, client, commander_mock, store):
     assert retval['objects'] == [dict(object_type=obj_type, object_data=obj)] * 2
 
 
-async def test_resolve_id(app, client, commander_mock, store):
+async def test_resolve_id(app, client, commander_mock, store, mocker):
+    random_mock = mocker.patch(TESTED + '.random_string')
+    random_mock.return_value = 'totally random string'
+
     await store.insert_multiple([
         {
             'service_id': 'alias',
@@ -115,6 +118,4 @@ async def test_resolve_id(app, client, commander_mock, store):
     assert await ctrl.resolve_service_id(ctrl._object_store, [1, 2, 3]) == 'alias'
     assert await ctrl.resolve_service_id(ctrl._object_store, 'testey') == 'testey'
     # Service ID not found: create placeholder
-    assert await ctrl.resolve_service_id(ctrl._object_store, [6, 6, 6]) == '6-6-6'
-    # Placeholder service ID already taken - degrade to controller ID
-    assert await ctrl.resolve_service_id(ctrl._object_store, [4, 2]) == [4, 2]
+    assert await ctrl.resolve_service_id(ctrl._object_store, [6, 6, 6]) == 'totally random string'


### PR DESCRIPTION
Resolves BrewBlox/brewblox-service#39

* The Object API modifies cache when creating, writing and updating. Read, all, and all_data functions have an optional `refresh` arguments.
* If read, all, or all_data don't find any relevant objects in the cache, they will attempt to refresh the cache.
* Refresh arguments are added to REST endpoints as query parameter. Any value evaluates as truthy.
* The Alias API updates the object cache when updating an alias.
* The `updater` module was added. Every `update_interval` seconds this uses the object API to refresh all objects.