### PR TITLE
add unique id to balanced constraint and fix time unit for pwm and mutex

### DIFF
--- a/brewblox_devcon_spark/codec/proto-compiled/ActuatorPwm_pb2.py
+++ b/brewblox_devcon_spark/codec/proto-compiled/ActuatorPwm_pb2.py
@@ -22,7 +22,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='blox',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\x11\x41\x63tuatorPwm.proto\x12\x04\x62lox\x1a\x0e\x62rewblox.proto\x1a\x0cnanopb.proto\x1a\x17\x41nalogConstraints.proto\"\xef\x01\n\x0b\x41\x63tuatorPwm\x12\x1f\n\nactuatorId\x18\x01 \x01(\rB\x0b\x8a\xb5\x18\x02\x18\x06\x92?\x02\x38\x10\x12\x0e\n\x06period\x18\x03 \x01(\r\x12#\n\x07setting\x18\x04 \x01(\x11\x42\x12\x8a\xb5\x18\x02\x30\x01\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x12\'\n\x05value\x18\x05 \x01(\x11\x42\x18\x8a\xb5\x18\x02\x30\x01\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x8a\xb5\x18\x02(\x01\x12.\n\rconstrainedBy\x18\x06 \x01(\x0b\x32\x17.blox.AnalogConstraints\x12(\n\x0estrippedFields\x18\x63 \x03(\rB\x10\x8a\xb5\x18\x02(\x01\x92?\x02\x38\x10\x92?\x02\x10\x02:\x07\x8a\xb5\x18\x03\x18\xb3\x02\x62\x06proto3')
+  serialized_pb=_b('\n\x11\x41\x63tuatorPwm.proto\x12\x04\x62lox\x1a\x0e\x62rewblox.proto\x1a\x0cnanopb.proto\x1a\x17\x41nalogConstraints.proto\"\xfe\x01\n\x0b\x41\x63tuatorPwm\x12\x1f\n\nactuatorId\x18\x01 \x01(\rB\x0b\x8a\xb5\x18\x02\x18\x06\x92?\x02\x38\x10\x12\x1d\n\x06period\x18\x03 \x01(\rB\r\x8a\xb5\x18\x02\x08\x04\x8a\xb5\x18\x03\x10\xe8\x07\x12#\n\x07setting\x18\x04 \x01(\x11\x42\x12\x8a\xb5\x18\x02\x30\x01\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x12\'\n\x05value\x18\x05 \x01(\x11\x42\x18\x8a\xb5\x18\x02\x30\x01\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x8a\xb5\x18\x02(\x01\x12.\n\rconstrainedBy\x18\x06 \x01(\x0b\x32\x17.blox.AnalogConstraints\x12(\n\x0estrippedFields\x18\x63 \x03(\rB\x10\x8a\xb5\x18\x02(\x01\x92?\x02\x38\x10\x92?\x02\x10\x02:\x07\x8a\xb5\x18\x03\x18\xb3\x02\x62\x06proto3')
   ,
   dependencies=[brewblox__pb2.DESCRIPTOR,nanopb__pb2.DESCRIPTOR,AnalogConstraints__pb2.DESCRIPTOR,])
 
@@ -49,7 +49,7 @@ _ACTUATORPWM = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
+      serialized_options=_b('\212\265\030\002\010\004\212\265\030\003\020\350\007'), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='setting', full_name='blox.ActuatorPwm.setting', index=2,
       number=4, type=17, cpp_type=1, label=1,
@@ -91,7 +91,7 @@ _ACTUATORPWM = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=83,
-  serialized_end=322,
+  serialized_end=337,
 )
 
 _ACTUATORPWM.fields_by_name['constrainedBy'].message_type = AnalogConstraints__pb2._ANALOGCONSTRAINTS
@@ -107,6 +107,7 @@ _sym_db.RegisterMessage(ActuatorPwm)
 
 
 _ACTUATORPWM.fields_by_name['actuatorId']._options = None
+_ACTUATORPWM.fields_by_name['period']._options = None
 _ACTUATORPWM.fields_by_name['setting']._options = None
 _ACTUATORPWM.fields_by_name['value']._options = None
 _ACTUATORPWM.fields_by_name['strippedFields']._options = None

--- a/brewblox_devcon_spark/codec/proto-compiled/AnalogConstraints_pb2.py
+++ b/brewblox_devcon_spark/codec/proto-compiled/AnalogConstraints_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='blox',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\x17\x41nalogConstraints.proto\x12\x04\x62lox\x1a\x0e\x62rewblox.proto\x1a\x0cnanopb.proto\"\xf6\x01\n\x10\x41nalogConstraint\x12\x1b\n\x03min\x18\x01 \x01(\x11\x42\x0c\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 H\x00\x12\x1b\n\x03max\x18\x02 \x01(\x11\x42\x0c\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 H\x00\x12\x33\n\x08\x62\x61lanced\x18\x03 \x01(\x0b\x32\x1f.blox.AnalogConstraint.BalancedH\x00\x12\x18\n\x08limiting\x18\x64 \x01(\x08\x42\x06\x8a\xb5\x18\x02(\x01\x1aK\n\x08\x42\x61lanced\x12\x1f\n\nbalancerId\x18\x01 \x01(\rB\x0b\x8a\xb5\x18\x02\x18\x07\x92?\x02\x38\x10\x12\x1e\n\x07granted\x18\x02 \x01(\rB\r\x8a\xb5\x18\x03\x10\x80 \x8a\xb5\x18\x02(\x01\x42\x0c\n\nconstraint\"r\n\x11\x41nalogConstraints\x12\x32\n\x0b\x63onstraints\x18\x01 \x03(\x0b\x32\x16.blox.AnalogConstraintB\x05\x92?\x02\x10\x08\x12)\n\runconstrained\x18\x02 \x01(\x11\x42\x12\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x8a\xb5\x18\x02(\x01\x62\x06proto3')
+  serialized_pb=_b('\n\x17\x41nalogConstraints.proto\x12\x04\x62lox\x1a\x0e\x62rewblox.proto\x1a\x0cnanopb.proto\"\x8f\x02\n\x10\x41nalogConstraint\x12\x1b\n\x03min\x18\x01 \x01(\x11\x42\x0c\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 H\x00\x12\x1b\n\x03max\x18\x02 \x01(\x11\x42\x0c\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 H\x00\x12\x33\n\x08\x62\x61lanced\x18\x03 \x01(\x0b\x32\x1f.blox.AnalogConstraint.BalancedH\x00\x12\x18\n\x08limiting\x18\x64 \x01(\x08\x42\x06\x8a\xb5\x18\x02(\x01\x1a\x64\n\x08\x42\x61lanced\x12\x1f\n\nbalancerId\x18\x01 \x01(\rB\x0b\x8a\xb5\x18\x02\x18\x07\x92?\x02\x38\x10\x12\x1e\n\x07granted\x18\x02 \x01(\rB\r\x8a\xb5\x18\x03\x10\x80 \x8a\xb5\x18\x02(\x01\x12\x17\n\x02id\x18\x03 \x01(\rB\x0b\x8a\xb5\x18\x02(\x01\x92?\x02\x38\x08\x42\x0c\n\nconstraint\"r\n\x11\x41nalogConstraints\x12\x32\n\x0b\x63onstraints\x18\x01 \x03(\x0b\x32\x16.blox.AnalogConstraintB\x05\x92?\x02\x10\x08\x12)\n\runconstrained\x18\x02 \x01(\x11\x42\x12\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x8a\xb5\x18\x02(\x01\x62\x06proto3')
   ,
   dependencies=[brewblox__pb2.DESCRIPTOR,nanopb__pb2.DESCRIPTOR,])
 
@@ -49,6 +49,13 @@ _ANALOGCONSTRAINT_BALANCED = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=_b('\212\265\030\003\020\200 \212\265\030\002(\001'), file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='id', full_name='blox.AnalogConstraint.Balanced.id', index=2,
+      number=3, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=_b('\212\265\030\002(\001\222?\0028\010'), file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -62,7 +69,7 @@ _ANALOGCONSTRAINT_BALANCED = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=221,
-  serialized_end=296,
+  serialized_end=321,
 )
 
 _ANALOGCONSTRAINT = _descriptor.Descriptor(
@@ -116,7 +123,7 @@ _ANALOGCONSTRAINT = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=64,
-  serialized_end=310,
+  serialized_end=335,
 )
 
 
@@ -153,8 +160,8 @@ _ANALOGCONSTRAINTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=312,
-  serialized_end=426,
+  serialized_start=337,
+  serialized_end=451,
 )
 
 _ANALOGCONSTRAINT_BALANCED.containing_type = _ANALOGCONSTRAINT
@@ -198,6 +205,7 @@ _sym_db.RegisterMessage(AnalogConstraints)
 
 _ANALOGCONSTRAINT_BALANCED.fields_by_name['balancerId']._options = None
 _ANALOGCONSTRAINT_BALANCED.fields_by_name['granted']._options = None
+_ANALOGCONSTRAINT_BALANCED.fields_by_name['id']._options = None
 _ANALOGCONSTRAINT.fields_by_name['min']._options = None
 _ANALOGCONSTRAINT.fields_by_name['max']._options = None
 _ANALOGCONSTRAINT.fields_by_name['limiting']._options = None

--- a/brewblox_devcon_spark/codec/proto-compiled/Balancer_pb2.py
+++ b/brewblox_devcon_spark/codec/proto-compiled/Balancer_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='blox',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\x0e\x42\x61lancer.proto\x12\x04\x62lox\x1a\x0e\x62rewblox.proto\x1a\x0cnanopb.proto\"\xd2\x01\n\x08\x42\x61lancer\x12>\n\x07\x63lients\x18\x01 \x03(\x0b\x32\x1f.blox.Balancer.BalancedActuatorB\x0c\x8a\xb5\x18\x02\x30\x01\x8a\xb5\x18\x02(\x01\x1a}\n\x10\x42\x61lancedActuator\x12\x1d\n\x02id\x18\x01 \x01(\rB\x11\x8a\xb5\x18\x02\x18\x05\x92?\x02\x38\x10\x8a\xb5\x18\x02(\x01\x12%\n\trequested\x18\x02 \x01(\x11\x42\x12\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x8a\xb5\x18\x02(\x01\x12#\n\x07granted\x18\x03 \x01(\x11\x42\x12\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x8a\xb5\x18\x02(\x01:\x07\x8a\xb5\x18\x03\x18\xb5\x02\x62\x06proto3')
+  serialized_pb=_b('\n\x0e\x42\x61lancer.proto\x12\x04\x62lox\x1a\x0e\x62rewblox.proto\x1a\x0cnanopb.proto\"\xcc\x01\n\x08\x42\x61lancer\x12>\n\x07\x63lients\x18\x01 \x03(\x0b\x32\x1f.blox.Balancer.BalancedActuatorB\x0c\x8a\xb5\x18\x02\x30\x01\x8a\xb5\x18\x02(\x01\x1aw\n\x10\x42\x61lancedActuator\x12\x17\n\x02id\x18\x01 \x01(\rB\x0b\x8a\xb5\x18\x02(\x01\x92?\x02\x38\x08\x12%\n\trequested\x18\x02 \x01(\x11\x42\x12\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x8a\xb5\x18\x02(\x01\x12#\n\x07granted\x18\x03 \x01(\x11\x42\x12\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x8a\xb5\x18\x02(\x01:\x07\x8a\xb5\x18\x03\x18\xb5\x02\x62\x06proto3')
   ,
   dependencies=[brewblox__pb2.DESCRIPTOR,nanopb__pb2.DESCRIPTOR,])
 
@@ -41,7 +41,7 @@ _BALANCER_BALANCEDACTUATOR = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=_b('\212\265\030\002\030\005\222?\0028\020\212\265\030\002(\001'), file=DESCRIPTOR),
+      serialized_options=_b('\212\265\030\002(\001\222?\0028\010'), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='requested', full_name='blox.Balancer.BalancedActuator.requested', index=1,
       number=2, type=17, cpp_type=1, label=1,
@@ -69,7 +69,7 @@ _BALANCER_BALANCEDACTUATOR = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=131,
-  serialized_end=256,
+  serialized_end=250,
 )
 
 _BALANCER = _descriptor.Descriptor(
@@ -99,7 +99,7 @@ _BALANCER = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=55,
-  serialized_end=265,
+  serialized_end=259,
 )
 
 _BALANCER_BALANCEDACTUATOR.containing_type = _BALANCER

--- a/brewblox_devcon_spark/codec/proto-compiled/Balancer_pb2.py
+++ b/brewblox_devcon_spark/codec/proto-compiled/Balancer_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='blox',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\x0e\x42\x61lancer.proto\x12\x04\x62lox\x1a\x0e\x62rewblox.proto\x1a\x0cnanopb.proto\"\xcc\x01\n\x08\x42\x61lancer\x12>\n\x07\x63lients\x18\x01 \x03(\x0b\x32\x1f.blox.Balancer.BalancedActuatorB\x0c\x8a\xb5\x18\x02\x30\x01\x8a\xb5\x18\x02(\x01\x1aw\n\x10\x42\x61lancedActuator\x12\x17\n\x02id\x18\x01 \x01(\rB\x0b\x8a\xb5\x18\x02(\x01\x92?\x02\x38\x08\x12%\n\trequested\x18\x02 \x01(\x11\x42\x12\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x8a\xb5\x18\x02(\x01\x12#\n\x07granted\x18\x03 \x01(\x11\x42\x12\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x8a\xb5\x18\x02(\x01:\x07\x8a\xb5\x18\x03\x18\xb5\x02\x62\x06proto3')
+  serialized_pb=_b('\n\x0e\x42\x61lancer.proto\x12\x04\x62lox\x1a\x0e\x62rewblox.proto\x1a\x0cnanopb.proto\"\xdf\x01\n\x08\x42\x61lancer\x12>\n\x07\x63lients\x18\x01 \x03(\x0b\x32\x1f.blox.Balancer.BalancedActuatorB\x0c\x8a\xb5\x18\x02\x30\x01\x8a\xb5\x18\x02(\x01\x1a\x89\x01\n\x10\x42\x61lancedActuator\x12\x1d\n\x02id\x18\x01 \x01(\rB\x11\x8a\xb5\x18\x02\x30\x01\x8a\xb5\x18\x02(\x01\x92?\x02\x38\x08\x12+\n\trequested\x18\x02 \x01(\x11\x42\x18\x8a\xb5\x18\x02\x30\x01\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x8a\xb5\x18\x02(\x01\x12)\n\x07granted\x18\x03 \x01(\x11\x42\x18\x8a\xb5\x18\x02\x30\x01\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 \x8a\xb5\x18\x02(\x01:\x07\x8a\xb5\x18\x03\x18\xb5\x02\x62\x06proto3')
   ,
   dependencies=[brewblox__pb2.DESCRIPTOR,nanopb__pb2.DESCRIPTOR,])
 
@@ -41,21 +41,21 @@ _BALANCER_BALANCEDACTUATOR = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=_b('\212\265\030\002(\001\222?\0028\010'), file=DESCRIPTOR),
+      serialized_options=_b('\212\265\030\0020\001\212\265\030\002(\001\222?\0028\010'), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='requested', full_name='blox.Balancer.BalancedActuator.requested', index=1,
       number=2, type=17, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=_b('\212\265\030\003\020\200 \222?\0028 \212\265\030\002(\001'), file=DESCRIPTOR),
+      serialized_options=_b('\212\265\030\0020\001\212\265\030\003\020\200 \222?\0028 \212\265\030\002(\001'), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='granted', full_name='blox.Balancer.BalancedActuator.granted', index=2,
       number=3, type=17, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=_b('\212\265\030\003\020\200 \222?\0028 \212\265\030\002(\001'), file=DESCRIPTOR),
+      serialized_options=_b('\212\265\030\0020\001\212\265\030\003\020\200 \222?\0028 \212\265\030\002(\001'), file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -68,8 +68,8 @@ _BALANCER_BALANCEDACTUATOR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=131,
-  serialized_end=250,
+  serialized_start=132,
+  serialized_end=269,
 )
 
 _BALANCER = _descriptor.Descriptor(
@@ -99,7 +99,7 @@ _BALANCER = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=55,
-  serialized_end=259,
+  serialized_end=278,
 )
 
 _BALANCER_BALANCEDACTUATOR.containing_type = _BALANCER

--- a/brewblox_devcon_spark/codec/proto-compiled/Mutex_pb2.py
+++ b/brewblox_devcon_spark/codec/proto-compiled/Mutex_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='blox',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\x0bMutex.proto\x12\x04\x62lox\x1a\x0e\x62rewblox.proto\x1a\x0cnanopb.proto\"/\n\x05Mutex\x12\x1d\n\x15\x64ifferentActuatorWait\x18\x01 \x01(\r:\x07\x8a\xb5\x18\x03\x18\xb6\x02\x62\x06proto3')
+  serialized_pb=_b('\n\x0bMutex.proto\x12\x04\x62lox\x1a\x0e\x62rewblox.proto\x1a\x0cnanopb.proto\">\n\x05Mutex\x12,\n\x15\x64ifferentActuatorWait\x18\x01 \x01(\rB\r\x8a\xb5\x18\x02\x08\x04\x8a\xb5\x18\x03\x10\xe8\x07:\x07\x8a\xb5\x18\x03\x18\xb6\x02\x62\x06proto3')
   ,
   dependencies=[brewblox__pb2.DESCRIPTOR,nanopb__pb2.DESCRIPTOR,])
 
@@ -41,7 +41,7 @@ _MUTEX = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
+      serialized_options=_b('\212\265\030\002\010\004\212\265\030\003\020\350\007'), file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -55,7 +55,7 @@ _MUTEX = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=51,
-  serialized_end=98,
+  serialized_end=113,
 )
 
 DESCRIPTOR.message_types_by_name['Mutex'] = _MUTEX
@@ -69,5 +69,6 @@ Mutex = _reflection.GeneratedProtocolMessageType('Mutex', (_message.Message,), d
 _sym_db.RegisterMessage(Mutex)
 
 
+_MUTEX.fields_by_name['differentActuatorWait']._options = None
 _MUTEX._options = None
 # @@protoc_insertion_point(module_scope)

--- a/brewblox_devcon_spark/codec/proto/ActuatorPwm.proto
+++ b/brewblox_devcon_spark/codec/proto/ActuatorPwm.proto
@@ -10,7 +10,7 @@ message ActuatorPwm {
   option (brewblox_msg).objtype = ActuatorPwm;
 
   uint32 actuatorId = 1 [ (brewblox).objtype = ActuatorDigitalInterface, (nanopb).int_size = IS_16 ];
-  uint32 period = 3;
+  uint32 period = 3 [ (brewblox).unit = Time, (brewblox).scale = 1000 ];
   sint32 setting = 4 [ (brewblox).logged = true, (brewblox).scale = 4096, (nanopb).int_size = IS_32 ];
   sint32 value = 5 [ (brewblox).logged = true, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
   AnalogConstraints constrainedBy = 6;

--- a/brewblox_devcon_spark/codec/proto/AnalogConstraints.proto
+++ b/brewblox_devcon_spark/codec/proto/AnalogConstraints.proto
@@ -9,6 +9,7 @@ message AnalogConstraint {
   message Balanced {
     uint32 balancerId = 1 [ (brewblox).objtype = BalancerInterface, (nanopb).int_size = IS_16 ];
     uint32 granted = 2 [ (brewblox).scale = 4096, (brewblox).readonly = true ];
+    uint32 id = 3 [ (brewblox).readonly = true, (nanopb).int_size = IS_8 ];
   }
 
   oneof constraint {

--- a/brewblox_devcon_spark/codec/proto/Balancer.proto
+++ b/brewblox_devcon_spark/codec/proto/Balancer.proto
@@ -9,7 +9,7 @@ message Balancer {
   option (brewblox_msg).objtype = Balancer;
 
   message BalancedActuator {
-    uint32 id = 1 [ (brewblox).objtype = ActuatorAnalogInterface, (nanopb).int_size = IS_16, (brewblox).readonly = true ];
+    uint32 id = 1 [ (brewblox).readonly = true, (nanopb).int_size = IS_8 ];
     sint32 requested = 2 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
     sint32 granted = 3 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
   }

--- a/brewblox_devcon_spark/codec/proto/Balancer.proto
+++ b/brewblox_devcon_spark/codec/proto/Balancer.proto
@@ -9,9 +9,9 @@ message Balancer {
   option (brewblox_msg).objtype = Balancer;
 
   message BalancedActuator {
-    uint32 id = 1 [ (brewblox).readonly = true, (nanopb).int_size = IS_8 ];
-    sint32 requested = 2 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
-    sint32 granted = 3 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
+    uint32 id = 1 [ (brewblox).logged = true, (brewblox).readonly = true, (nanopb).int_size = IS_8 ];
+    sint32 requested = 2 [ (brewblox).logged = true, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
+    sint32 granted = 3 [ (brewblox).logged = true, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
   }
 
   repeated BalancedActuator clients = 1 [ (brewblox).logged = true, (brewblox).readonly = true ];

--- a/brewblox_devcon_spark/codec/proto/Mutex.proto
+++ b/brewblox_devcon_spark/codec/proto/Mutex.proto
@@ -8,5 +8,5 @@ package blox;
 message Mutex {
   option (brewblox_msg).objtype = Mutex;
 
-  uint32 differentActuatorWait = 1;
+  uint32 differentActuatorWait = 1 [ (brewblox).unit = Time, (brewblox).scale = 1000 ];
 }


### PR DESCRIPTION
The balancer didn't know who its clients were. Each balanced constraint now gets a unique ID from the balancer in the firmware.
The UI can resolve which actuator is the actual client by matching one with the same Balancer and requester id. Because object IDs are managed by the container and not part of the object, using the cbox ID as requester ID would have been much more difficult.

The time unit for the PWM period and the Mutex wait time were not set to seconds yet, which is included in this PR.

