### PR TITLE
add drivenTargetId to profile driver

### DIFF
--- a/brewblox_devcon_spark/codec/proto-compiled/SetpointProfile_pb2.py
+++ b/brewblox_devcon_spark/codec/proto-compiled/SetpointProfile_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='blox',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\x15SetpointProfile.proto\x12\x04\x62lox\x1a\x0e\x62rewblox.proto\x1a\x0cnanopb.proto\"\xb8\x01\n\x0fSetpointProfile\x12+\n\x06points\x18\x01 \x03(\x0b\x32\x1b.blox.SetpointProfile.Point\x12\x0f\n\x07\x65nabled\x18\x03 \x01(\x08\x12\x1e\n\x08targetId\x18\x04 \x01(\rB\x0c\x8a\xb5\x18\x03\x18\xaf\x02\x92?\x02\x38\x10\x1a>\n\x05Point\x12\x0c\n\x04time\x18\x01 \x01(\r\x12\'\n\x0btemperature\x18\x02 \x01(\x11\x42\x12\x8a\xb5\x18\x02\x08\x01\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 :\x07\x8a\xb5\x18\x03\x18\xb7\x02\x62\x06proto3')
+  serialized_pb=_b('\n\x15SetpointProfile.proto\x12\x04\x62lox\x1a\x0e\x62rewblox.proto\x1a\x0cnanopb.proto\"\xea\x01\n\x0fSetpointProfile\x12+\n\x06points\x18\x01 \x03(\x0b\x32\x1b.blox.SetpointProfile.Point\x12\x0f\n\x07\x65nabled\x18\x03 \x01(\x08\x12\x1e\n\x08targetId\x18\x04 \x01(\rB\x0c\x8a\xb5\x18\x03\x18\xaf\x02\x92?\x02\x38\x10\x12\x30\n\x0e\x64rivenTargetId\x18\x05 \x01(\rB\x18\x8a\xb5\x18\x03\x18\xaf\x02\x8a\xb5\x18\x02@\x01\x92?\x02\x38\x10\x8a\xb5\x18\x02(\x01\x1a>\n\x05Point\x12\x0c\n\x04time\x18\x01 \x01(\r\x12\'\n\x0btemperature\x18\x02 \x01(\x11\x42\x12\x8a\xb5\x18\x02\x08\x01\x8a\xb5\x18\x03\x10\x80 \x92?\x02\x38 :\x07\x8a\xb5\x18\x03\x18\xb7\x02\x62\x06proto3')
   ,
   dependencies=[brewblox__pb2.DESCRIPTOR,nanopb__pb2.DESCRIPTOR,])
 
@@ -61,8 +61,8 @@ _SETPOINTPROFILE_POINT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=175,
-  serialized_end=237,
+  serialized_start=225,
+  serialized_end=287,
 )
 
 _SETPOINTPROFILE = _descriptor.Descriptor(
@@ -93,6 +93,13 @@ _SETPOINTPROFILE = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=_b('\212\265\030\003\030\257\002\222?\0028\020'), file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='drivenTargetId', full_name='blox.SetpointProfile.drivenTargetId', index=3,
+      number=5, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=_b('\212\265\030\003\030\257\002\212\265\030\002@\001\222?\0028\020\212\265\030\002(\001'), file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -106,7 +113,7 @@ _SETPOINTPROFILE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=62,
-  serialized_end=246,
+  serialized_end=296,
 )
 
 _SETPOINTPROFILE_POINT.containing_type = _SETPOINTPROFILE
@@ -132,5 +139,6 @@ _sym_db.RegisterMessage(SetpointProfile.Point)
 
 _SETPOINTPROFILE_POINT.fields_by_name['temperature']._options = None
 _SETPOINTPROFILE.fields_by_name['targetId']._options = None
+_SETPOINTPROFILE.fields_by_name['drivenTargetId']._options = None
 _SETPOINTPROFILE._options = None
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
indicator for when a setpoint was driving a ss pair was missing