### PR TITLE
Limit serial write buffer to not overrun the spark receive buffer

### DIFF
--- a/brewblox_devcon_spark/communication.py
+++ b/brewblox_devcon_spark/communication.py
@@ -82,7 +82,7 @@ async def connect_serial(app: web.Application,
     loop = asyncio.get_event_loop()
     transport = SerialTransport(loop, protocol, ser)
     transport.serial.rts = False
-    transport.set_write_buffer_limits(high=255)
+    transport.set_write_buffer_limits(high=255) # receiver RX buffer is 256, so limit send buffer to 255
     return address, transport, protocol
 
 

--- a/brewblox_devcon_spark/communication.py
+++ b/brewblox_devcon_spark/communication.py
@@ -82,6 +82,7 @@ async def connect_serial(app: web.Application,
     loop = asyncio.get_event_loop()
     transport = SerialTransport(loop, protocol, ser)
     transport.serial.rts = False
+    transport.set_write_buffer_limits(high=255)
     return address, transport, protocol
 
 

--- a/brewblox_devcon_spark/communication.py
+++ b/brewblox_devcon_spark/communication.py
@@ -82,7 +82,7 @@ async def connect_serial(app: web.Application,
     loop = asyncio.get_event_loop()
     transport = SerialTransport(loop, protocol, ser)
     transport.serial.rts = False
-    transport.set_write_buffer_limits(high=255) # receiver RX buffer is 256, so limit send buffer to 255
+    transport.set_write_buffer_limits(high=255)  # receiver RX buffer is 256, so limit send buffer to 255
     return address, transport, protocol
 
 


### PR DESCRIPTION
Importing a lot of objects caused a hard fault SOS on the spark over serial, but not over WiFi.

Limiting the pyserial write buffer to 255 prevents this from happening. The controller's serial buffer is 256 bytes.