### PR TITLE
Reduce regex calls during message parsing.

### DIFF
--- a/brewblox_devcon_spark/cbox_parser.py
+++ b/brewblox_devcon_spark/cbox_parser.py
@@ -11,7 +11,9 @@ from brewblox_service import brewblox_logger
 LOGGER = brewblox_logger(__name__)
 
 # Pattern: '{start}(?P<message>[^{start}]*?){end}'
+EVENT_END = '>'
 EVENT_PATTERN = re.compile('<(?P<message>[^<]*?)>')
+DATA_END = '\n'
 DATA_PATTERN = re.compile('^(?P<message>[^^]*?)\n')
 
 
@@ -37,7 +39,7 @@ class ControlboxParser():
         # Annotations use < and > as start/end characters
         # Most annotations can be discarded, except for event messages
         # Event messages are annotations that start with !
-        for msg in self._coerce_message_from_buffer(EVENT_PATTERN):
+        for msg in self._coerce_message_from_buffer(EVENT_PATTERN, EVENT_END):
             if msg.startswith('!'):  # Event
                 self._events.put(msg[1:])
             else:
@@ -45,7 +47,7 @@ class ControlboxParser():
 
         # Once annotations are filtered, all that remains is data
         # Data is newline-separated
-        for msg in self._coerce_message_from_buffer(DATA_PATTERN):
+        for msg in self._coerce_message_from_buffer(DATA_PATTERN, DATA_END):
             self._data.put(msg)
 
     def _extract_message(self, matchobj: re.Match) -> str:
@@ -53,7 +55,7 @@ class ControlboxParser():
         self._messages.append(msg)
         return ''
 
-    def _coerce_message_from_buffer(self, pattern: re.Pattern):
+    def _coerce_message_from_buffer(self, pattern: re.Pattern, end: str):
         """ Filters separate messages from the buffer.
 
         It makes some assumptions about messages:
@@ -80,8 +82,10 @@ class ControlboxParser():
         """
         prev_len = 0
 
+        # Don't bother checking if end char is not in buffer
         # Break the loop when buffer is unchanged after re.sub()
-        while prev_len != len(self._buffer):
+        # The break is required if the buffer receives malformed data
+        while end in self._buffer and prev_len != len(self._buffer):
             prev_len = len(self._buffer)
             self._buffer = re.sub(
                 pattern=pattern,


### PR DESCRIPTION
The controlbox parser uses a while loop to extract possibly nested messages from the buffer.
While the pattern is in the buffer, it calls re.sub() to remove it, and then re-evaluates the remainder.

```
# pseudocode
while message in buffer:
    buffer -= message
    yield message
```

The initial check was done using `re.search('.*{start_character}.*{end_character}', self._buffer)`.
Profiling revealed this to be a major CPU bottleneck, as it is compiled and checked multiple times for each received data chunk.

The obvious step is to compile regex patterns only once, and keep them as module constant.

Simple logging under normal conditions revealed that in the vast majority of calls to `_coerce_message_from_buffer`, no message was found (checked: 2269, found: 38).
This suggested that using a faster (non-regex) check for the while guard would significantly improve performance.

The most straightforward replacement for the search pattern is `start in buffer and end in buffer`.
The problem with this is that malformed data may consist of an end character without a start character. Using this naive check there would result in an infinite loop.
A buffer consisting of `XXXXX [end] [start] XXXXX` is not only possible, but very likely when connecting to an USB device that has some leftover buffered data.

The extracting re.sub() call is used to modify the buffer: we pull messages from the buffer until all (interleavened) messages are extracted.
If re.sub() makes no changes to the buffer, then apparently there was no message in there. This information can be used to break the loop.
We don't care about content, and changes are always subtractive: a length check is enough.

Conclusion: `end in buffer` is a much faster alternative to re.search() for the majority of checks, and if we add a `if last_sub_modified_buffer` check, we can prevent malformed data causing endless loops.