### PR TITLE
Fix for enabled setting not being applied

### DIFF
--- a/brewblox_devcon_spark/endpoints/http_settings.py
+++ b/brewblox_devcon_spark/endpoints/http_settings.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter
 
 from .. import datastore_settings
 from ..models import AutoconnectSettings
+from .. import state_machine
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +30,9 @@ async def settings_enabled_put(args: AutoconnectSettings) -> AutoconnectSettings
     Set enabled flag.
     """
     store = datastore_settings.CV.get()
-    store.service_settings.enabled = args.enabled
-    await store.commit_service_settings()
+    store.service_settings.enabled = args.enabled # update local settings
+    state_machine.CV.get().set_enabled(args.enabled) # apply settings
+    await store.commit_service_settings() # commit local settings to datastore
+    # change event from MQTT will come in, but settings are the same and callbacks will be skipped.
+    # if we would only apply on MQTT event, toggling enabled would depend on round trip through the datastore and eventbus.
     return AutoconnectSettings(enabled=args.enabled)

--- a/brewblox_devcon_spark/endpoints/http_settings.py
+++ b/brewblox_devcon_spark/endpoints/http_settings.py
@@ -30,9 +30,9 @@ async def settings_enabled_put(args: AutoconnectSettings) -> AutoconnectSettings
     Set enabled flag.
     """
     store = datastore_settings.CV.get()
-    store.service_settings.enabled = args.enabled # update local settings
-    state_machine.CV.get().set_enabled(args.enabled) # apply settings
-    await store.commit_service_settings() # commit local settings to datastore
+    store.service_settings.enabled = args.enabled  # update local settings
+    state_machine.CV.get().set_enabled(args.enabled)  # apply settings
+    await store.commit_service_settings()  # commit local settings to datastore
     # change event from MQTT will come in, but settings are the same and callbacks will be skipped.
-    # if we would only apply on MQTT event, toggling enabled would depend on round trip through the datastore and eventbus.
+    # if we would only apply on MQTT event, it would depend on round trip through the datastore and eventbus.
     return AutoconnectSettings(enabled=args.enabled)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ omit = [
 
 [tool.flake8]
 max-line-length = 120
-exclude = "*_pb2.py,.venv"
+exclude = "*_pb2.py,.venv,.eggs"
 
 [tool.autopep8]
 max-line-length = 120

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -513,11 +513,14 @@ async def test_settings_api(client: AsyncClient, block_args: Block):
     resp = await client.post('/blocks/create', json=block_args.model_dump())
     assert resp.status_code == 201
 
+    state = state_machine.CV.get()
     resp = await client.get('/settings/enabled')
     assert resp.json() == {'enabled': True}
+    assert state.is_enabled()
 
     resp = await client.put('/settings/enabled', json={'enabled': False})
     assert resp.json() == {'enabled': False}
+    assert not state.is_enabled()
 
     resp = await client.get('/settings/enabled')
     assert resp.json() == {'enabled': False}


### PR DESCRIPTION
The only place where the enabled setting was applied to the state machine was when an MQTT changed event was received.

Old buggy implementation:
- change local setting, send to db, receive changed event, compare to (already equal) local setting, skip apply
New implementation
- change local setting, apply, send to db, receive changed event, compare to (already equal) local setting, skip apply

The alternative would be to not copy immediately to local settings, send the new data to the db and apply it on MQTT changed event. I have chosen to apply immediately to avoid dependency on db and MQTT.