### PR TITLE
prevent unused files to end up in docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@
 *.egg-info
 brewblox-proto
 test
+firmware/*.map
+firmware/*.lst

--- a/Dockerfile.flasher
+++ b/Dockerfile.flasher
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile:1.7-labs
+# syntax=docker/dockerfile:1-labs
 FROM python:3.11-slim-bookworm
 
 ENV PIP_EXTRA_INDEX_URL=https://www.piwheels.org/simple
@@ -15,12 +15,12 @@ RUN <<EOF bash
         libatomic1 \
         usbutils
 
-    pip3 install \
+    pip3 install --no-cache-dir \
         cffi==1.17.1 \
         cryptography==42.0.8 \
         esptool
 
-    CLI_VERSION="3.24.0"
+    CLI_VERSION="3.29.1"
     ARCH="$(dpkg --print-architecture)"
     if [ "\${ARCH}" = "amd64" ]; then
         CLI_ARCH="x64"
@@ -41,6 +41,6 @@ RUN <<EOF bash
     rm -rf /var/cache/apt/archives /var/lib/apt/lists
 EOF
 
-COPY --exclude=*.sim ./firmware/* ./
+COPY --exclude=*.sim firmware/ ./
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile.flasher
+++ b/Dockerfile.flasher
@@ -8,6 +8,7 @@ WORKDIR /app
 RUN <<EOF bash
     set -ex
 
+    # Install only runtime dependencies
     apt-get update -q
     apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -15,11 +16,13 @@ RUN <<EOF bash
         libatomic1 \
         usbutils
 
-    pip3 install --no-cache-dir \
+    # Install Python dependencies using only pre-built wheels
+    pip3 install --only-binary=:all: \
         cffi==1.17.1 \
         cryptography==42.0.8 \
         esptool
 
+    # Install Particle CLI
     CLI_VERSION="3.29.1"
     ARCH="$(dpkg --print-architecture)"
     if [ "\${ARCH}" = "amd64" ]; then
@@ -37,7 +40,9 @@ RUN <<EOF bash
     chmod +x ./particle
     mv ./particle /usr/local/bin/
 
+    # Clean up
     apt-get autoremove -y
+    apt-get clean
     rm -rf /var/cache/apt/archives /var/lib/apt/lists
 EOF
 

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -24,12 +24,15 @@ RUN ARCH="$(dpkg --print-architecture)"; \
     set -ex; \
     cd /app/firmware; \
     if [ "$ARCH" = "amd64" ]; then \
-    rm -f ./brewblox-{arm32,arm64}.sim; \
+    echo "Building for amd64"; \
+    rm -f brewblox-arm32.sim; rm -f brewblox-arm64.sim; \
     elif [ "$ARCH" = "armhf" ]; then \
-    rm -f ./brewblox-{amd64,arm64}.sim; \
+    echo "Building for armhf"; \
+    rm -f brewblox-amd64.sim; rm -f brewblox-arm64.sim; \
     elif [ "$ARCH" = "arm64" ]; then \
-    rm -f ./brewblox-{amd64,arm32}.sim; \
-    fi
+    echo "Building for arm64"; \
+    rm -f ./brewblox-amd64.sim; rm -f brewblox-arm32.sim; \
+    fi;
 
 FROM python:3.11-slim-bookworm
 EXPOSE 5000

--- a/brewblox_devcon_spark/models.py
+++ b/brewblox_devcon_spark/models.py
@@ -78,6 +78,7 @@ class ResetData(enum.Enum):
     LISTENING_MODE_EXIT = '05'
     FIRMWARE_UPDATE_SUCCESS = '06'
     OUT_OF_MEMORY = '07'
+    FIRMWARE_UPDATE_TCP_SERVER_FAILED = '08'
 
     def __str__(self):
         return self.name

--- a/brewblox_devcon_spark/state_machine.py
+++ b/brewblox_devcon_spark/state_machine.py
@@ -166,7 +166,7 @@ class StateMachine:
 
     def set_synchronized(self):
         if not self._acknowledged_ev.is_set():
-            raise RuntimeError('Failed to set synchronized status: ' 'service is not acknowledged')
+            raise RuntimeError('Failed to set synchronized status: service is not acknowledged')
 
         self._status_desc.connection_status = 'SYNCHRONIZED'
 

--- a/tasks.py
+++ b/tasks.py
@@ -107,7 +107,7 @@ def testclean(ctx: Context):
 @task()
 def image(ctx: Context, tag='local'):
     with ctx.cd(ROOT):
-        ctx.run(f'docker build -t ghcr.io/brewblox/brewblox-devcon-spark:{tag} -f Dockerfile.service .')
+        ctx.run(f'docker build --load -t ghcr.io/brewblox/brewblox-devcon-spark:{tag} -f Dockerfile.service .')
 
 
 @task()
@@ -121,7 +121,7 @@ def buildx(ctx: Context, tag='local', platform='linux/amd64,linux/arm/v7,linux/a
 @task()
 def flasher_image(ctx: Context, tag='local'):
     with ctx.cd(ROOT):
-        ctx.run(f'docker build -t ghcr.io/brewblox/brewblox-firmware-flasher:{tag} -f Dockerfile.flasher .')
+        ctx.run(f'docker build --load -t ghcr.io/brewblox/brewblox-firmware-flasher:{tag} -f Dockerfile.flasher .')
 
 
 @task()

--- a/test/test_connection_cbox_parser.py
+++ b/test/test_connection_cbox_parser.py
@@ -31,7 +31,7 @@ def expected_events():
 
 
 def expected_data():
-    return ['0A' '00' '01' '28C80E9A0300009C', '34234']
+    return ['0A' + '00' + '01' + '28C80E9A0300009C', '34234']
 
 
 def test_parser():


### PR DESCRIPTION
Slightly reduce docker images by omitting files that are not used:
- sim for other architectures
- sim in flasher
- map file